### PR TITLE
- Fix: Background change interation trough KDE Plasma Settings

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -36,7 +36,12 @@ Pane {
   font.pointSize: config.fontSize || (height / 80)
   property string iconFont: config.iconFont || config.fontFamily
 
+  property string backgroundPath:config.background
+  property string backgroundType:config.type || "image"
+
   background: Rectangle {
+    height: root.height
+    width: root.width
     color: config.backgroundColour
 
     Image {
@@ -45,7 +50,7 @@ Pane {
       height: root.height
       width: root.width
 
-      source: config.wallpaper
+      source: backgroundType === "image" ? root.backgroundPath : config.wallpaper
       fillMode: config.boolValue("fitWallpaper") ? Image.PreserveAspectFit : Image.PreserveAspectCrop
 
       asynchronous: true


### PR DESCRIPTION
Fixes interation when changing wallpaper trough the System Settings.

- KDE Changes a SDDM wallpaper trough `theme.conf.user` with the image path and image type.
- If the wallpaper is changed, it will use the theme.conf.user "background"
- If the wallpaper change is removed, KDE alters the Image Type to "color", fallbacking to `theme.conf`'s wallpaper.